### PR TITLE
Preventing comment reopens with advanced diffing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ghcr.io/ekline-io/ekline-cli:4.4.0
+RUN apk add jq --no-cache
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,7 +44,7 @@ if [ -e "$previous_feedback_file" ]; then
   # Create a temporary directory for storing intermediate files
   temp_dir=$(mktemp -d)
 
-  # Build a hash table of entries from the previous feedback
+  # Build a hash table of entries from the running feedback log
   while IFS= read -r other_entry; do
     # Extract line, location, and error type from the entry
     line=$(echo "$other_entry" | jq -r '.location.range.start.line')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
 
+# Determine the CI environment
 if [ "$GITLAB_CI" = "true" ]; then
   input_workspace="$CI_PROJECT_DIR"
   rd_api_token="$INPUT_GITLAB_TOKEN"
@@ -14,6 +15,7 @@ else
   exit 1
 fi
 
+# Set workspace directory and safe.directory
 if [ -n "${input_workspace}" ] ; then
   cd "${input_workspace}/${INPUT_WORKDIR}" || exit
   git config --global --add safe.directory "${input_workspace}" || exit 1
@@ -21,11 +23,75 @@ fi
 
 export REVIEWDOG_GITLAB_API_TOKEN="${rd_api_token}"
 export REVIEWDOG_GITHUB_API_TOKEN="${rd_api_token}"
+export GITHUB_TOKEN="${rd_api_token}"
 
 output="ekOutput.jsonl"
 ekline -cd "${INPUT_CONTENT_DIR}" -et "${INPUT_EK_TOKEN}"  -o "${output}" -i "${INPUT_IGNORE_RULE}" "${disable_suggestions}"
 
-LEVEL=${INPUT_LEVEL:-info}
+# Path to the fresh comment file
+ekoutput_file="./EkOutput.jsonl"
+
+# Path to the historic reviewdog file
+other_file="./fetched-artifact/EkOutput.jsonl"
+
+# Temporary file for storing non-matching entries
+temp_file="./ekoutput_filtered.jsonl"
+
+# Create a temporary directory for storing intermediate files
+temp_dir=$(mktemp -d)
+
+ # Build a hash table of entries from the second file
+ while IFS= read -r other_entry; do
+   echo "Processing entry: $other_entry"
+
+   # Extract line, location, and error type from the entry
+   line=$(echo "$other_entry" | jq -r '.location.range.start.line')
+   location=$(echo "$other_entry" | jq -r '.location.path')
+   error_type=$(echo "$other_entry" | grep -oE '\[EK[0-9]{5}\]' | head -n1 | tr -d '[]')
+
+   # Generate a hash key based on line, location, and error type
+   hash_key="${line}_${location}_${error_type}"
+
+   # Create a temporary file for the hash key if it doesn't exist
+   hash_file="$temp_dir/$hash_key"
+   mkdir -p "$(dirname "$hash_file")"
+   touch "$hash_file"
+
+   # Append the entry to the hash file
+   echo "$other_entry" >> "$hash_file"
+ done < "$other_file"
+
+ # Iterate through the entries in the first file
+ while IFS= read -r entry; do
+   # Extract line, location, and error type from the entry
+   line=$(echo "$entry" | jq -r '.location.range.start.line')
+   location=$(echo "$entry" | jq -r '.location.path')
+   error_type=$(echo "$entry" | grep -oE '\[EK[0-9]{5}\]' | head -n1 | tr -d '[]')
+
+   # Generate a hash key based on line, location, and error type
+   hash_key="${line}_${location}_${error_type}"
+
+   # Check if the hash file for the hash key exists
+   hash_file="$temp_dir/$hash_key"
+   if [ -f "$hash_file" ]; then
+     # Match found, skip this entry
+     continue
+   fi
+
+   # Append non-matching entries to the temporary file
+   echo "$entry" >> "$temp_file"
+ done < "$ekoutput_file"
+
+ # Replace the original file with the filtered entries if it exists
+ if [ -e "$temp_file" ]; then
+   mv "$temp_file" "$ekoutput_file"
+ fi
+
+ # Clean up temporary directory
+ rm -rf "$temp_dir"
+
+ LEVEL=${INPUT_LEVEL:-info}
+
 
 < "$output" reviewdog -f="rdjsonl" \
   -name="EkLine" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,7 +44,7 @@ if [ -e "$previous_feedback_file" ]; then
   # Create a temporary directory for storing intermediate files
   temp_dir=$(mktemp -d)
 
-  # Build a hash table of entries from the second file
+  # Build a hash table of entries from the previous feedback
   while IFS= read -r other_entry; do
     # Extract line, location, and error type from the entry
     line=$(echo "$other_entry" | jq -r '.location.range.start.line')
@@ -63,7 +63,7 @@ if [ -e "$previous_feedback_file" ]; then
     echo "$other_entry" >> "$hash_file"
   done < "$previous_feedback_file"
 
-  # Iterate through the entries in the first file
+  # Iterate through the entries in the new feedback
   while IFS= read -r entry; do
     # Extract line, location, and error type from the entry
     line=$(echo "$entry" | jq -r '.location.range.start.line')
@@ -80,18 +80,18 @@ if [ -e "$previous_feedback_file" ]; then
       continue
     fi
 
-    # Append non-matching entries to the file that shows the unique
+    # Append non-matching entries to the file that stores unique entries
     echo "$entry" >> "$temp_file"
 
-    # Append non-matching entries to the file that will get stored as a running log
+    # Append non-matching entries to the file that will store a running feedback log
     echo "$entry" >> "$previous_feedback_file"
   done < "$current_output"
 
   if [ -f "$temp_file" ]; then
-    # Replace current Ekline output run with the unique entries file
+    # Replace current feedback with the unique feedback file
     mv "$temp_file" "$current_output"
   else
-    # This means that we have no unique entries in this run, so blank out the reviewdog output file
+    # This means that we have no unique entries in this run, so blank out the feedback file
     > "$current_output"
   fi
   # Clean up temporary directory
@@ -100,7 +100,7 @@ else
   echo "No previous feedback exists"
   # No historical data, so we make current output = historical output to be saved
     if [ -f "$current_output" ]; then
-      # THe file exists, so the copy is possible, else nothing to do
+      # The file exists, so the copy is possible, else nothing to do
       mkdir -p "$previous_feedback_directory"
       cp "$current_output" "$previous_feedback_file"
     fi


### PR DESCRIPTION
### Description of change

Changing entrypoint.sh to enable advanced diffing

### Pull-Request Checklist

- [N] Do you need to update the ekline-cli version in Dockerfile? Did you?  --> No
- [N] Did you update the README

To see an example of this code at work - See

https://github.com/ekline-io/ekline-github-action-private/runs/14176493434 -- Initial run with 86 comments
https://github.com/ekline-io/ekline-github-action-private/runs/14176547585 -- Follow up run with only 1 comment
https://github.com/ekline-io/ekline-github-action-private/runs/14177359260 -- Last run with no comment

Sample YML file for the functionality to work: https://github.com/ekline-io/ekline-github-action-private/blob/no-feedback-retrigger4/.github/workflows/test.yml
