### PR TITLE
feat: EK-527 support for multiple content directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ Improve the quality and consistency of your documentation with EkLine, an automa
 ```yaml
 inputs:
   content_dir:
-    description: 'Multiple space separated content directories relative to the root directory.'
+    description: 'Content directories relative to the root. Specify a single path or multiple paths (one per line). Example:
+      content_dir: ./testData
+      content_dir: |
+        ./testData
+        ./testData2'
     default: '.'
   ek_token:
     description: 'Token for EkLine application'
@@ -71,7 +75,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ekline-io/ekline-github-action@v6
         with:
-          content_dir: ./src/docs ./src/content
+          content_dir: ./src/docs
           ek_token: ${{ secrets.ek_token }}
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Improve the quality and consistency of your documentation with EkLine, an automa
 ```yaml
 inputs:
   content_dir:
-    description: 'Content directory relative to the root directory.'
+    description: 'Multiple space separated content directories relative to the root directory.'
     default: '.'
   ek_token:
     description: 'Token for EkLine application'
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ekline-io/ekline-github-action@v6
         with:
-          content_dir: ./src/docs
+          content_dir: ./src/docs ./src/content
           ek_token: ${{ secrets.ek_token }}
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: 'Token for EkLine application'
     required: true
   content_dir:
-    description: 'Content directory relative to the root directory.'
+    description: 'Multiple space separated content directories relative to the root directory.'
     default: '.'
   ignore_rule:
     description: 'Ignore the rules that are passed in as comma seperated values (eg: EK1,EK4)'

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,11 @@ inputs:
     description: 'Token for EkLine application'
     required: true
   content_dir:
-    description: 'Multiple space separated content directories relative to the root directory.'
+    description: 'Content directories relative to the root. Specify a single path or multiple paths (one per line). Example:
+      content_dir: ./testData
+      content_dir: |
+        ./testData
+        ./testData2'
     default: '.'
   ignore_rule:
     description: 'Ignore the rules that are passed in as comma seperated values (eg: EK1,EK4)'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -131,7 +131,7 @@ if [ -n "${changed_files}" ]; then
 fi
 
 
-ekline -cd "${INPUT_CONTENT_DIR}" -et "${INPUT_EK_TOKEN}" ${cf_option} -o "${output}" -i "${INPUT_IGNORE_RULE}" "${disable_suggestions}" "${ai_suggestions}"
+ekline -cd ${INPUT_CONTENT_DIR} -et "${INPUT_EK_TOKEN}" ${cf_option} -o "${output}" -i "${INPUT_IGNORE_RULE}" "${disable_suggestions}" "${ai_suggestions}"
 
 if [ -s "$output" ]; then
   if [ "$GITHUB_ACTIONS" = "true" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -131,7 +131,19 @@ if [ -n "${changed_files}" ]; then
 fi
 
 
-ekline -cd ${INPUT_CONTENT_DIR} -et "${INPUT_EK_TOKEN}" ${cf_option} -o "${output}" -i "${INPUT_IGNORE_RULE}" "${disable_suggestions}" "${ai_suggestions}"
+ekline_args=""
+while IFS= read -r dir; do
+  if [ -n "$dir" ]; then
+    ekline_args="$ekline_args -cd \"$dir\""
+  fi
+done <<EOF
+$INPUT_CONTENT_DIR
+EOF
+
+ekline_command="ekline $ekline_args -et \"${INPUT_EK_TOKEN}\" ${cf_option} -o \"${output}\" -i \"${INPUT_IGNORE_RULE}\" ${disable_suggestions} ${ai_suggestions}"
+
+eval "$ekline_command"
+
 
 if [ -s "$output" ]; then
   if [ "$GITHUB_ACTIONS" = "true" ]; then


### PR DESCRIPTION
# Support Multiple Content Directories in ekline-github-action

This PR enables the `ekline-github-action` to handle multiple content directories. By passing `INPUT_CONTENT_DIR` in `entrypoint.sh`, users can now specify multiple space-separated directories in the `content_dir` input parameter. This change allows `ekline-cli` to process files from all provided directories, enhancing flexibility for projects with documentation in various locations.

# Jira ticket
[Link](https://ekline.atlassian.net/jira/software/projects/EK/boards/1?assignee=712020%3Abf39a77b-882a-43e0-98b9-696d31875731&selectedIssue=EK-66)
