### PR TITLE
Fixed the issue in ekline-cli running with spaced file names.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -138,11 +138,16 @@ ai_suggestions=""
 if [ -n "${pull_request_id}" ] || [ "$enable_ai_suggestions" = "true" ] ; then
   ai_suggestions="--ai-suggestions"
 fi
+
 cf_option=""
 if [ -n "${changed_files}" ]; then
-  cf_option="-cf $@"
+    cf_option="-cf"
+    while IFS= read -r file; do
+        cf_option="$cf_option \"$file\""
+    done <<EOF
+${changed_files}
+EOF
 fi
-
 
 ekline_args=""
 while IFS= read -r dir; do


### PR DESCRIPTION
### Description of change
Change has made in the parsing of difference b/w files fetched from the github and parsed for cf-option, to converted filenames strings into double quotes surrounded strings.
...

### Pull-Request Checklist

- [ ] Do you need to update the ekline-cli version in Dockerfile? Did you? 
- [ ] Did you update the README
