### PR TITLE
fix(release): EK-326: use different GitHub command to get latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
         id: get_latest_tag
         run: |
           # Get the latest release tag
-          LATEST_TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName')
+          LATEST_TAG=$(gh release view  --json tagName --jq '.tagName')
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
           echo "Latest tag: $LATEST_TAG"
         env:


### PR DESCRIPTION
https://ekline.atlassian.net/browse/EK-326

### Description of change

The release process has been failing today because `gh release list` isn't guaranteed to return the latest release first. Props to @puneet-ekline for coming up with this `gh release view` workaround.