### PR TITLE
fix: EK-733: duplicated GitLab comments

### DIFF
--- a/.github/actions/fetch-reviewdog/action.yml
+++ b/.github/actions/fetch-reviewdog/action.yml
@@ -1,0 +1,17 @@
+name: Fetch Reviewdog
+description: Downloads the latest reviewdog binary
+inputs:
+  token:
+    description: Personal access token (PAT) used to fetch the reviewdog binary.
+    default: ${{ github.token }}
+runs:
+  using: "composite"
+  steps:
+    - uses: robinraju/release-downloader@v1
+      with:
+        repository: "ekline-io/reviewdog"
+        tag: "v0.21.0"
+        fileName: "*_Linux_x86_64.tar.gz"
+        out-file-path: dist
+        extract: true
+        token: ${{ inputs.token }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -4,10 +4,14 @@ on:
     branches:
       - main
   pull_request:
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: ./.github/actions/fetch-reviewdog
+      with:
+        token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag ${{ github.repository }}:$(date +%s)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - if: "steps.tag.outputs.value != ''"
+        uses: ./.github/actions/fetch-reviewdog
+        with:
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+
+      - if: "steps.tag.outputs.value != ''"
         name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -248,6 +253,10 @@ jobs:
             type=semver,pattern=v{{major}},value=${{ steps.bump_version.outputs.new_tag }}
             type=raw,value=latest
       
+      - uses: ./.github/actions/fetch-reviewdog
+        with:
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM ghcr.io/ekline-io/ekline-cli:7
 
 RUN apk add --no-cache npm util-linux curl jq --update
 
+COPY dist/reviewdog /usr/local/bin/reviewdog
+
 RUN mkdir /code
 
 WORKDIR /code


### PR DESCRIPTION
[EK-733](https://ekline.atlassian.net/browse/EK-733)

### Description of change

Recently a customer reported that EkLine had added hundreds of comments to a GitLab merge request after the workflow was run multiple times. It turns out that reviewdog was lacking support for comment de-duplication in GitLab [reviewdog #1150](https://github.com/reviewdog/reviewdog/issues/1150). This PR updates `ekline-github-action` to use a fork of reviewdog that contains the added support.

[EK-733]: https://ekline.atlassian.net/browse/EK-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ